### PR TITLE
Make networking feature opt-in

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [features]
-default = ["networking"]
+default = []
 networking = ["reqwest"]
 
 [target.'cfg(windows)'.build-dependencies]


### PR DESCRIPTION
An optional feature for networking was introduced, but since it's part of `default`, it's always enabled unless you build with `--no-default-features`. Fix that by omitting `networking` from `default`.