### PR TITLE
Don't show update message if version is newer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -365,21 +365,11 @@ fn check_for_updates() -> bool {
 				let curr_patch = env!("CARGO_PKG_VERSION_PATCH");
 				println!("Current version is '{}.{}.{}'", curr_major, curr_minor, curr_patch);
 
-				let latest_full = info.tag_name.chars().skip(1).collect::<String>();
+				// Trim letters from the start of the version tag, e.g. "v1.9" -> "1.9"
+				let latest_full = info.tag_name.trim_start_matches(char::is_alphabetic);
 				let mut latest_parts = latest_full.split('.');
-				let mut extract_part = || {
-					let result;
-					if let Some(part) = latest_parts.next() {
-						if part.is_empty() {
-							result = "0";
-						} else {
-							result = part;
-						}
-					} else {
-						result = "0";
-					}
-					result
-				};
+				let mut extract_part =
+					|| latest_parts.next().filter(|&s| !s.is_empty()).unwrap_or("0");
 				let latest_major = extract_part();
 				let latest_minor = extract_part();
 				let latest_patch = extract_part();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@
 extern crate error_chain;
 
 use std::cell::{Cell, RefCell};
+use std::cmp;
 use std::f32;
+use std::num::ParseIntError;
 use std::rc::Rc;
 use std::sync::{
 	atomic::{AtomicBool, Ordering},
@@ -385,11 +387,14 @@ fn check_for_updates() -> bool {
 					"Parsed latest version is '{}.{}.{}'",
 					latest_major, latest_minor, latest_patch
 				);
-				if curr_major != latest_major
-					|| curr_minor != latest_minor
-					|| curr_patch != latest_patch
-				{
-					return true;
+
+				match compare_semver_versions(
+					(curr_major, curr_minor, curr_patch),
+					(latest_major, latest_minor, latest_patch),
+				) {
+					Ok(cmp::Ordering::Less) => return true,
+					Ok(_) => {}
+					Err(error) => println!("Error parsing version: {}", error.to_string()),
 				}
 			}
 			Err(e) => println!("Failed to create json from response: {}", e),
@@ -397,4 +402,32 @@ fn check_for_updates() -> bool {
 		Err(e) => println!("Failed to get latest version info: {}", e),
 	}
 	false
+}
+
+#[cfg(feature = "networking")]
+/// Compare two versions using semantic versioning.
+/// Both versions are represented as a tuple `(MAJOR, MINOR, PATCH)`.
+fn compare_semver_versions(
+	current: (&str, &str, &str),
+	latest: (&str, &str, &str),
+) -> Result<cmp::Ordering, ParseIntError> {
+	use cmp::Ordering::*;
+
+	// Fast path if versions are identical
+	if current == latest {
+		return Ok(Equal);
+	}
+
+	let current: (u32, u32, u32) = (current.0.parse()?, current.1.parse()?, current.2.parse()?);
+	let latest: (u32, u32, u32) = (latest.0.parse()?, latest.1.parse()?, latest.2.parse()?);
+
+	Ok(match current.0.cmp(&latest.0) {
+		Greater => Greater,
+		Less => Less,
+		Equal => match current.1.cmp(&latest.1) {
+			Greater => Greater,
+			Less => Less,
+			Equal => current.2.cmp(&latest.2),
+		},
+	})
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,44 @@
+use std::fmt;
+use std::{num::ParseIntError, str::FromStr};
+
+/// A semver version
+#[derive(Debug, Default, PartialEq, PartialOrd, Eq, Ord)]
+pub struct Version {
+	major: u32,
+	minor: u32,
+	patch: u32,
+}
+
+impl Version {
+	/// Return the version of the cargo build
+	pub fn cargo_pkg_version() -> Self {
+		let major = env!("CARGO_PKG_VERSION_MAJOR").parse().expect("Invalid cargo version");
+		let minor = env!("CARGO_PKG_VERSION_MINOR").parse().expect("Invalid cargo version");
+		let patch = env!("CARGO_PKG_VERSION_PATCH").parse().expect("Invalid cargo version");
+
+		Version { major, minor, patch }
+	}
+}
+
+impl fmt::Display for Version {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+	}
+}
+
+impl FromStr for Version {
+	type Err = ParseIntError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		// Trim letters from the start of the version tag, e.g. "v1.9" -> "1.9"
+		let mut iter = s.trim_start_matches(char::is_alphabetic).split('.');
+		// Consume the next part of the version tag
+		let mut extract_part = || iter.next().filter(|&n| !n.is_empty()).unwrap_or("0");
+
+		let major = extract_part().parse()?;
+		let minor = extract_part().parse()?;
+		let patch = extract_part().parse()?;
+
+		Ok(Version { major, minor, patch })
+	}
+}


### PR DESCRIPTION
Fixes #39 

This also refactors version parsing by introducing a `Version` struct. The `Ord` trait is `#[derive]`d which works as expected: `1.8.9` < `1.9.0` < `2.0.0` < `2.1.0`