### PR TITLE
Save last update check

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -25,7 +25,7 @@ pub struct UpdateSection {
 impl UpdateSection {
 	pub fn should_check(&self) -> bool {
 		if self.has_update || self.disable_update_check {
-			true
+			false
 		} else {
 			let duration = SystemTime::now()
 				.duration_since(UNIX_EPOCH + Duration::from_secs(self.last_checked))

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,10 +1,8 @@
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::{
-	path::Path,
-	time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct WindowSection {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -31,7 +31,7 @@ impl UpdateSection {
 				.duration_since(UNIX_EPOCH + Duration::from_secs(self.last_checked))
 				.unwrap_or_else(|_| Duration::from_secs(0));
 
-			duration > Duration::from_secs(60 * 10)
+			duration > Duration::from_secs(60 * 60 * 24) // 24 hours
 		}
 	}
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -15,14 +15,13 @@ pub struct WindowSection {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct UpdateSection {
-	pub has_update: bool,
-	pub disable_update_check: bool,
+	pub check_updates: bool,
 	pub last_checked: u64,
 }
 
 impl UpdateSection {
 	pub fn should_check(&self) -> bool {
-		if self.has_update || self.disable_update_check {
+		if !self.check_updates {
 			false
 		} else {
 			let duration = SystemTime::now()
@@ -33,8 +32,7 @@ impl UpdateSection {
 		}
 	}
 
-	pub fn set_has_update(&mut self, has_update: bool) {
-		self.has_update = has_update;
+	pub fn set_update_check_time(&mut self) {
 		self.last_checked = SystemTime::now()
 			.duration_since(UNIX_EPOCH)
 			.unwrap_or_else(|_| Duration::from_secs(0))
@@ -73,11 +71,7 @@ impl Default for Configuration {
 		Configuration {
 			window: WindowSection { dark: false, win_w: 580, win_h: 558, win_x: 64, win_y: 64 },
 			bindings: None,
-			updates: UpdateSection {
-				has_update: false,
-				disable_update_check: false,
-				last_checked: 0,
-			},
+			updates: UpdateSection { check_updates: true, last_checked: 0 },
 		}
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,14 +312,11 @@ fn main() {
 		if updates.should_check() {
 			// kick off a thread that will check for an update in the background
 			Some(std::thread::spawn(move || {
-				let has_update = check_for_updates();
-				update_available.store(has_update, Ordering::SeqCst);
+				update_available.store(check_for_updates(), Ordering::SeqCst);
 				update_check_done.store(true, Ordering::SeqCst);
-				config.lock().unwrap().updates.set_has_update(has_update);
+				config.lock().unwrap().updates.set_update_check_time();
 			}))
 		} else {
-			update_available.store(updates.has_update, Ordering::SeqCst);
-			update_check_done.store(true, Ordering::SeqCst);
 			None
 		}
 	};

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,7 +303,6 @@ fn main() {
 
 	window.set_root(vertical_container);
 
-	// kick off a thread that will check for an update in the background
 	let update_checker_join_handle = {
 		let updates = &mut config.lock().unwrap().updates;
 		let config = config.clone();
@@ -311,6 +310,7 @@ fn main() {
 		let update_check_done = update_check_done.clone();
 
 		if updates.should_check() {
+			// kick off a thread that will check for an update in the background
 			Some(std::thread::spawn(move || {
 				let has_update = check_for_updates();
 				update_available.store(has_update, Ordering::SeqCst);
@@ -323,6 +323,7 @@ fn main() {
 			None
 		}
 	};
+
 	let mut nothing_to_do = false;
 	application.add_global_event_handler(move |_| {
 		if nothing_to_do {
@@ -382,7 +383,7 @@ fn check_for_updates() -> bool {
 
 				match Version::from_str(&info.tag_name) {
 					Ok(latest) => {
-						println!("Parsed latest version is {}", latest);
+						println!("Parsed latest version is '{}'", latest);
 
 						if latest > current {
 							return true;

--- a/src/picture_widget.rs
+++ b/src/picture_widget.rs
@@ -21,7 +21,10 @@ use gelatin::window::Window;
 use gelatin::NextUpdate;
 use gelatin::{DrawContext, Event, EventKind, Widget, WidgetData, WidgetError};
 
-use std::time::{Duration, Instant};
+use std::{
+	sync::{Arc, Mutex},
+	time::{Duration, Instant},
+};
 
 static TOGGLE_FULLSCREEN_NAME: &str = "toggle_fullscreen";
 static IMG_NEXT_NAME: &str = "img_next";
@@ -67,7 +70,7 @@ struct PictureWidgetData {
 	click: bool,
 	hover: bool,
 
-	configuration: Rc<RefCell<Configuration>>,
+	configuration: Arc<Mutex<Configuration>>,
 	playback_manager: PlaybackManager,
 
 	program: Program,
@@ -154,7 +157,7 @@ impl PictureWidget {
 		window: &Rc<Window>,
 		slider: Rc<gelatin::slider::Slider>,
 		bottom_panel: Rc<HorizontalLayoutContainer>,
-		configuration: Rc<RefCell<Configuration>>,
+		configuration: Arc<Mutex<Configuration>>,
 	) -> PictureWidget {
 		let program = program!(display,
 			140 => {
@@ -255,12 +258,12 @@ impl PictureWidget {
 	}
 
 	fn triggered(
-		config: &Rc<RefCell<Configuration>>,
+		config: &Arc<Mutex<Configuration>>,
 		action_name: &str,
 		input_key: &str,
 		modifiers: ModifiersState,
 	) -> bool {
-		let config = config.borrow();
+		let config = config.lock().unwrap();
 		let bindings = config.bindings.as_ref();
 		if let Some(Some(keys)) = bindings.map(|b| b.get(action_name)) {
 			Self::keys_triggered(keys.as_slice(), input_key, modifiers)


### PR DESCRIPTION
Extends the config file to store

- ~if an update is available (bool)~
- when we last checked for updates (unix timestamp)
- if checking for updates should be enabled (bool)

Now, we only check for updates if ~no update is available according to the config file,~ checking for updates isn't disabled and the last check was at least 24 hours ago.

Fixes #41 