### PR TITLE
Correctly change img bounds when resizing window

### DIFF
--- a/src/picture_widget.rs
+++ b/src/picture_widget.rs
@@ -95,6 +95,9 @@ impl WidgetData for PictureWidgetData {
 	fn drawn_bounds(&mut self) -> &mut LogicalRect {
 		&mut self.drawn_bounds
 	}
+	fn drawn_bounds_updated(&mut self) {
+		self.hover = self.drawn_bounds.contains(self.last_mouse_pos);
+	}
 	fn visible(&mut self) -> &mut bool {
 		&mut self.visible
 	}

--- a/subcrates/gelatin/src/lib.rs
+++ b/subcrates/gelatin/src/lib.rs
@@ -64,6 +64,8 @@ pub trait WidgetData {
 	/// window in logical pixels. This area does not include the widget's margins.
 	fn drawn_bounds(&mut self) -> &mut LogicalRect;
 
+	/// This function is called every time after the drawn bounds were updated using the trait methods
+	/// `apply_horizontal_alignement`, `apply_vertical_alignement` or `default_layout`.
 	fn drawn_bounds_updated(&mut self) {}
 
 	fn visible(&mut self) -> &mut bool;

--- a/subcrates/gelatin/src/lib.rs
+++ b/subcrates/gelatin/src/lib.rs
@@ -64,6 +64,8 @@ pub trait WidgetData {
 	/// window in logical pixels. This area does not include the widget's margins.
 	fn drawn_bounds(&mut self) -> &mut LogicalRect;
 
+	fn drawn_bounds_updated(&mut self) {}
+
 	fn visible(&mut self) -> &mut bool;
 
 	fn apply_horizontal_alignement(&mut self, available_space: LogicalRect, width: f32) {
@@ -84,6 +86,7 @@ pub trait WidgetData {
 					available_space.right() - (self.placement().margin_right + width);
 			}
 		}
+		self.drawn_bounds_updated();
 	}
 	fn apply_vertical_alignement(&mut self, available_space: LogicalRect, height: f32) {
 		self.drawn_bounds().pos.vec.y = available_space.pos.vec.y;
@@ -103,6 +106,7 @@ pub trait WidgetData {
 					available_space.bottom() - (self.placement().margin_bottom + height);
 			}
 		}
+		self.drawn_bounds_updated();
 	}
 	fn default_layout(&mut self, available_space: LogicalRect) {
 		if !*self.visible() {
@@ -110,6 +114,7 @@ pub trait WidgetData {
 				pos: LogicalVector::new(0.0, 0.0),
 				size: LogicalVector::new(0.0, 0.0),
 			};
+			self.drawn_bounds_updated();
 			return;
 		}
 		*self.drawn_bounds() = available_space;
@@ -146,6 +151,7 @@ pub trait WidgetData {
 				self.drawn_bounds().pos.vec.y += self.placement().margin_top;
 			}
 		}
+		self.drawn_bounds_updated();
 	}
 }
 
@@ -309,6 +315,8 @@ pub struct Event {
 	pub modifiers: glutin::event::ModifiersState,
 	pub kind: EventKind,
 }
+
+#[derive(Debug)]
 pub enum EventKind {
 	MouseMove,
 	MouseButton { state: glutin::event::ElementState, button: glutin::event::MouseButton },


### PR DESCRIPTION
Fixes #38 

When updating the `drawn_bounds` of the picture widget directly after opening emulsion or entering fullscreen, the `hover` property wasn't updated, which caused bug #38.