### PR TITLE
Command line ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b89647f09b9f4c838cb622799b2843e4e13bff64661dab9a0362bb92985addd"
 
 [[package]]
+name = "clap"
+version = "2.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +480,7 @@ version = "2.0.0"
 dependencies = [
  "alphanumeric-sort",
  "backtrace",
+ "clap",
  "directories",
  "error-chain",
  "gelatin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1687,6 +1699,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36ae8932fcfea38b7d3883ae2ab357b0d57a02caaa18ebb4f5ece08beaec4aa0"
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "tiff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1791,12 @@ checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ toml = "0.5"
 rand = "0.7"
 alphanumeric-sort = "1.0"
 trash = "1.0"
+clap = { version = "2.33", default-features = false }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -16,12 +16,23 @@ fn print_help() {
 	print_version();
 	println!("A fast and minimalistic image viewer");
 	println!("Artur Barnabas <kovacs.artur.barnabas@gmail.com>");
+	println!("https://arturkovacs.github.io/emulsion-website/");
 	println!("\n{}", USAGE);
 	println!("\n{}", OPTIONS);
+	print_cfg_paths();
 }
 
 fn print_version() {
 	println!("emulsion {}", Version::cargo_pkg_version());
+}
+
+fn print_cfg_paths() {
+	let (config_path, cache_path) = crate::get_config_and_cache_paths();
+	println!(
+		"\nCONFIGURATION:\n    config file: {}\n    cache file:  {}",
+		config_path.to_string_lossy(),
+		cache_path.to_string_lossy(),
+	);
 }
 
 /// Contains the command-line arguments

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,106 +1,25 @@
 use crate::Version;
+use clap::{App, Arg};
+use std::path::PathBuf;
 
-static USAGE: &str = "USAGE:
-    emulsion [OPTIONS] <FILE PATH>";
-
-static OPTIONS: &str = "OPTIONS:
-    -h, --help      Prints help information
-    -V, --version   Prints version information";
-
-fn print_usage() {
-	println!("{}", USAGE);
-	println!("\nFor more information try --help");
-}
-
-fn print_help() {
-	print_version();
-	println!("A fast and minimalistic image viewer");
-	println!("Artur Barnabas <kovacs.artur.barnabas@gmail.com>");
-	println!("https://arturkovacs.github.io/emulsion-website/");
-	println!("\n{}", USAGE);
-	println!("\n{}", OPTIONS);
-	print_cfg_paths();
-}
-
-fn print_version() {
-	println!("emulsion {}", Version::cargo_pkg_version());
-}
-
-fn print_cfg_paths() {
-	let (config_path, cache_path) = crate::get_config_and_cache_paths();
-	println!(
-		"\nCONFIGURATION:\n    config file: {}\n    cache file:  {}",
+/// Parses the command-line arguments and returns the file path
+pub fn parse_args(config_path: &PathBuf, cache_path: &PathBuf) -> String {
+	let config = format!(
+		"CONFIGURATION:\n    config file: {}\n    cache file:  {}",
 		config_path.to_string_lossy(),
 		cache_path.to_string_lossy(),
 	);
-}
 
-/// Contains the command-line arguments
-struct Args {
-	help: bool,
-	version: bool,
-	file_path: Option<String>,
-}
+	let matches = App::new("emulsion")
+		.version(Version::cargo_pkg_version().to_string().as_str())
+		.author("Artur Barnabas <kovacs.artur.barnabas@gmail.com>")
+		.about(
+			"A fast and minimalistic image viewer\n\
+			https://arturkovacs.github.io/emulsion-website/",
+		)
+		.after_help(config.as_str())
+		.arg(Arg::with_name("PATH").help("The file path of the image").index(1).required(true))
+		.get_matches();
 
-/// Parses the command-line arguments
-fn parse_args() -> Result<Args, String> {
-	let mut help = false;
-	let mut version = false;
-	let mut file_path = None;
-
-	for arg in std::env::args().skip(1) {
-		if arg.starts_with("--") {
-			// parse argument
-			match arg.as_str() {
-				"--help" => help = true,
-				"--version" => version = true,
-				_ => return Err(format!("Argument '{}' supported", arg)),
-			}
-		} else if arg == "-help" {
-			help = true;
-		} else if arg.starts_with("-") && arg.len() > 1 {
-			// parse flags
-			for flag in arg[1..].chars() {
-				match flag {
-					'h' => help = true,
-					'V' => version = true,
-					_ => return Err(format!("Flag '-{}' not supported", flag)),
-				}
-			}
-		} else {
-			if file_path.is_some() {
-				return Err(format!("More than one file argument provided"));
-			}
-			file_path = Some(arg);
-		}
-	}
-
-	Ok(Args { help, version, file_path })
-}
-
-/// Return the file path passed to emulsion.
-///
-/// If the help or version flag was used, display the requested information instead.
-pub fn get_file_path() -> Option<String> {
-	match parse_args() {
-		Ok(args) => {
-			if args.help {
-				print_help();
-				return None;
-			} else if args.version {
-				print_version();
-				return None;
-			} else if args.file_path.is_none() {
-				eprintln!("Error: No image file provided\n");
-				print_usage();
-				return None;
-			}
-			return args.file_path;
-		}
-		Err(msg) => {
-			eprintln!("Error: {}\n", msg);
-			print_usage();
-			return None;
-		}
-	}
+	matches.value_of("PATH").unwrap().to_owned()
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -3,7 +3,7 @@ use clap::{App, Arg};
 use std::path::PathBuf;
 
 /// Parses the command-line arguments and returns the file path
-pub fn parse_args(config_path: &PathBuf, cache_path: &PathBuf) -> String {
+pub fn parse_args(config_path: &PathBuf, cache_path: &PathBuf) -> Option<String> {
 	let config = format!(
 		"CONFIGURATION:\n    config file: {}\n    cache file:  {}",
 		config_path.to_string_lossy(),
@@ -18,8 +18,8 @@ pub fn parse_args(config_path: &PathBuf, cache_path: &PathBuf) -> String {
 			https://arturkovacs.github.io/emulsion-website/",
 		)
 		.after_help(config.as_str())
-		.arg(Arg::with_name("PATH").help("The file path of the image").index(1).required(true))
+		.arg(Arg::with_name("PATH").help("The file path of the image").index(1))
 		.get_matches();
 
-	matches.value_of("PATH").unwrap().to_owned()
+	matches.value_of("PATH").map(ToString::to_string)
 }

--- a/src/cmd_line.rs
+++ b/src/cmd_line.rs
@@ -1,0 +1,95 @@
+use crate::Version;
+
+static USAGE: &str = "USAGE:
+    emulsion [OPTIONS] <FILE PATH>";
+
+static OPTIONS: &str = "OPTIONS:
+    -h, --help      Prints help information
+    -V, --version   Prints version information";
+
+fn print_usage() {
+	println!("{}", USAGE);
+	println!("\nFor more information try --help");
+}
+
+fn print_help() {
+	print_version();
+	println!("A fast and minimalistic image viewer");
+	println!("Artur Barnabas <kovacs.artur.barnabas@gmail.com>");
+	println!("\n{}", USAGE);
+	println!("\n{}", OPTIONS);
+}
+
+fn print_version() {
+	println!("emulsion {}", Version::cargo_pkg_version());
+}
+
+/// Contains the command-line arguments
+struct Args {
+	help: bool,
+	version: bool,
+	file_path: Option<String>,
+}
+
+/// Parses the command-line arguments
+fn parse_args() -> Result<Args, String> {
+	let mut help = false;
+	let mut version = false;
+	let mut file_path = None;
+
+	for arg in std::env::args().skip(1) {
+		if arg.starts_with("--") {
+			// parse argument
+			match arg.as_str() {
+				"--help" => help = true,
+				"--version" => version = true,
+				_ => return Err(format!("Argument '{}' supported", arg)),
+			}
+		} else if arg == "-help" {
+			help = true;
+		} else if arg.starts_with("-") && arg.len() > 1 {
+			// parse flags
+			for flag in arg[1..].chars() {
+				match flag {
+					'h' => help = true,
+					'V' => version = true,
+					_ => return Err(format!("Flag '-{}' not supported", flag)),
+				}
+			}
+		} else {
+			if file_path.is_some() {
+				return Err(format!("More than one file argument provided"));
+			}
+			file_path = Some(arg);
+		}
+	}
+
+	Ok(Args { help, version, file_path })
+}
+
+/// Return the file path passed to emulsion.
+///
+/// If the help or version flag was used, display the requested information instead.
+pub fn get_file_path() -> Option<String> {
+	match parse_args() {
+		Ok(args) => {
+			if args.help {
+				print_help();
+				return None;
+			} else if args.version {
+				print_version();
+				return None;
+			} else if args.file_path.is_none() {
+				eprintln!("Error: No image file provided\n");
+				print_usage();
+				return None;
+			}
+			return args.file_path;
+		}
+		Err(msg) => {
+			eprintln!("Error: {}\n", msg);
+			print_usage();
+			return None;
+		}
+	}
+}

--- a/src/image_cache/mod.rs
+++ b/src/image_cache/mod.rs
@@ -93,7 +93,7 @@ pub struct AnimationFrameTexture {
 
 struct CachedTexture {
 	/// Contains the load request id
-	req_id: u32,
+	_req_id: u32,
 	needs_update: bool,
 	mod_time: Option<SystemTime>,
 
@@ -177,7 +177,7 @@ impl ImageCache {
 		}
 	}
 
-	pub fn cached_from_dir(&self) -> Vec<bool> {
+	pub fn _cached_from_dir(&self) -> Vec<bool> {
 		let mut result = Vec::with_capacity(self.dir_files.len());
 		for desc in self.dir_files.iter() {
 			result.push(self.texture_cache.contains_key(&desc.request_id));
@@ -383,7 +383,7 @@ impl ImageCache {
 		frame_jump_count: isize,
 	) -> Result<(AnimationFrameTexture, OsString)> {
 		if file_jump_count == 0 {
-			let path = self.current_file_path();
+			let _path = self.current_file_path();
 			// Here, it is possible that the current image was already
 			// requested but not yet loaded.
 			let target_frame = self.current_frame_idx as isize + frame_jump_count;
@@ -556,7 +556,7 @@ impl ImageCache {
 				match self.texture_cache.entry(req_id) {
 					Entry::Vacant(entry) => {
 						entry.insert(CachedTexture {
-							req_id,
+							_req_id: req_id,
 							needs_update: false,
 							fully_loaded: false,
 							mod_time: curr_mod_time,
@@ -707,7 +707,7 @@ impl ImageCache {
 		self.remaining_capacity = self.total_capacity;
 
 		// Cancel all pending load requests
-		for (id, request) in self.ongoing_requests.iter_mut() {
+		for (_id, request) in self.ongoing_requests.iter_mut() {
 			request.cancelled = true;
 		}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,7 @@ fn make_picture_widget(
 	picture_widget
 }
 
-fn get_config_and_cache_paths() -> (PathBuf, PathBuf) {
+pub fn get_config_and_cache_paths() -> (PathBuf, PathBuf) {
 	let config_folder;
 	let cache_folder;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,13 +67,10 @@ static USAGE: &[u8] = include_bytes!("../resource/usage.png");
 fn main() {
 	std::panic::set_hook(Box::new(handle_panic::handle_panic));
 
-	let file_path = match cmd_line::get_file_path() {
-		Some(args) => args,
-		None => return,
-	};
-
 	// Load configuration and cache files
 	let (config_path, cache_path) = get_config_and_cache_paths();
+
+	let file_path = cmd_line::parse_args(&config_path, &cache_path);
 
 	let cache = Cache::load(&cache_path);
 	let config = Configuration::load(&config_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ fn check_for_updates() -> bool {
 					}
 				}
 				Err(error) => {
-					eprintln!("Error parsing version: {}", error.to_string());
+					eprintln!("Error parsing version: {}", error);
 				}
 			},
 			Err(e) => eprintln!("Failed to create json from response: {}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,9 @@ fn main() {
 	let picture_widget =
 		make_picture_widget(&window, bottom_bar.slider(), bottom_bar.widget(), config.clone());
 
-	picture_widget.jump_to_path(file_path);
+	if let Some(file_path) = file_path {
+		picture_widget.jump_to_path(file_path);
+	}
 
 	let picture_area_container = make_picture_area_container();
 	picture_area_container.add_child(picture_widget.clone());
@@ -391,6 +393,7 @@ mod update {
 
 	/// Tries to parse version tag and compare against current version
 	fn compare_release(info: &ReleaseInfoJson) -> errors::Result<bool> {
+		use crate::version::Version;
 		use std::str::FromStr;
 
 		let current = Version::cargo_pkg_version();

--- a/src/playback_manager.rs
+++ b/src/playback_manager.rs
@@ -123,7 +123,7 @@ impl PlaybackManager {
 				((value.total / 8) * 1024) as isize
 			}
 			_ => {
-				println!("Could not get system memory size, using default value");
+				eprintln!("Could not get system memory size, using default value");
 				// bytes
 				500_000_000
 			}

--- a/src/playback_manager.rs
+++ b/src/playback_manager.rs
@@ -134,7 +134,7 @@ impl PlaybackManager {
 			_ => 4,
 		};
 
-		let mut result = PlaybackManager {
+		let result = PlaybackManager {
 			//playback_state: PlaybackState::Paused,
 			image_cache: ImageCache::new(cache_capaxity, thread_count),
 			folder_player: ImgSequencePlayer::new(
@@ -188,7 +188,7 @@ impl PlaybackManager {
 		// self.playback_state = PlaybackState::Present;
 	}
 
-	pub fn current_filename(&self) -> OsString {
+	pub fn _current_filename(&self) -> OsString {
 		self.image_cache.current_filename()
 	}
 
@@ -211,8 +211,8 @@ impl PlaybackManager {
 		Ok(())
 	}
 
-	pub fn cached_from_dir(&self) -> Vec<bool> {
-		self.image_cache.cached_from_dir()
+	pub fn _cached_from_dir(&self) -> Vec<bool> {
+		self.image_cache._cached_from_dir()
 	}
 
 	pub fn request_load(&mut self, request: LoadRequest) {
@@ -345,7 +345,7 @@ impl ImgSequencePlayer {
 		self.image_texture.clone().map(|t| t.texture)
 	}
 
-	pub fn filename(&self) -> &Option<OsString> {
+	pub fn _filename(&self) -> &Option<OsString> {
 		&self.filename
 	}
 


### PR DESCRIPTION
Errors are now correctly printed to stderr with `eprintln!()`.

Emulsion now use [clap](https://crates.io/crates/clap), and accepts two options, `--version/-V` and `--help/-h`.

This should make it easy to add new options, if the need arises.

In case of an error (if ~no file or~ more than one file is provided, or an unsupported option is used), an error message is printed and no window is opened.

(This also silences some warnings, e.g. by adding `_` to identifiers)

Closes #64 

Try it:

```
❯ cargo run -- -h
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/emulsion -h`
emulsion 2.0.0
Artur Barnabas <kovacs.artur.barnabas@gmail.com>
A fast and minimalistic image viewer
https://arturkovacs.github.io/emulsion-website/

USAGE:
    emulsion <PATH>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <PATH>    The file path of the image

CONFIGURATION:
    config file: /home/ludwig/.config/emulsion/cfg.toml
    cache file:  /home/ludwig/.cache/emulsion/cache.toml
```