### PR TITLE
Enable O1 in debug and LTO in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ members = [
     "subcrates/gelatin",
 ]
 
+[profile.dev.package."*"]
+opt-level = 1
+[profile.dev.build-override]
+opt-level = 1
+[profile.release]
+lto = true
+
 [features]
 default = []
 networking = ["ureq", "serde_json"]


### PR DESCRIPTION
We enable O1 for debug builds, since image decoding is cpu-bound.