### PR TITLE
Replace unmaintained 'directories' crate with 'directories-next'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,22 +437,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "2.0.2"
+name = "directories-next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+checksum = "21eaa04e945bec7e2dc7383817c566881d9a83d20a07cc949b54585873585a48"
 dependencies = [
  "cfg-if",
- "dirs-sys",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.4"
+name = "dirs-sys-next"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
- "cfg-if",
  "libc",
  "redox_users",
  "winapi 0.3.8",
@@ -498,7 +497,7 @@ dependencies = [
  "alphanumeric-sort",
  "backtrace",
  "clap",
- "directories",
+ "directories-next",
  "error-chain",
  "gelatin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ winres = "0.1"
 gelatin = "0.3"
 ureq = { version = "1", features = ["json"], optional = true }
 lazy_static = "1.4.0"
-directories = "2.0.2"
+directories-next = "1.0"
 open = "1.4.0"
 sys-info = "=0.5.8"
 error-chain = "0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use directories::ProjectDirs;
+use directories_next::ProjectDirs;
 use lazy_static::lazy_static;
 
 use gelatin::glium::glutin::{


### PR DESCRIPTION
The [`directories`](https://github.com/soc/directories-rs) crate is unmaintained and its repository is archived. This PR replaces it with the maintained [`directories-next`](https://github.com/xdg-rs/dirs/tree/master/directories) fork.