### PR TITLE
Log image loading errors and request IDs

### DIFF
--- a/src/image_cache/image_loader.rs
+++ b/src/image_cache/image_loader.rs
@@ -228,11 +228,18 @@ impl ImageLoader {
 			Ok(())
 		}
 
-		if try_load_and_send(img_sender, &request).is_ok() {
-			img_sender.send(LoadResult::Done { req_id: request.req_id }).unwrap();
-		} else {
-			img_sender.send(LoadResult::Failed { req_id: request.req_id }).unwrap();
-		}
+		img_sender
+			.send(match try_load_and_send(img_sender, &request) {
+				Ok(()) => LoadResult::Done { req_id: request.req_id },
+				Err(error) => {
+					eprintln!(
+						"Request #{}: Error occured while loading file {:?}\n    {}",
+						request.req_id, request.path, error,
+					);
+					LoadResult::Failed { req_id: request.req_id }
+				}
+			})
+			.unwrap();
 	}
 }
 

--- a/src/image_cache/image_loader.rs
+++ b/src/image_cache/image_loader.rs
@@ -233,7 +233,7 @@ impl ImageLoader {
 				Ok(()) => LoadResult::Done { req_id: request.req_id },
 				Err(error) => {
 					eprintln!(
-						"Request #{}: Error occured while loading file {:?}\n    {}",
+						"Request #{}: Error occurred while loading file {:?}\n    {}",
 						request.req_id, request.path, error,
 					);
 					LoadResult::Failed { req_id: request.req_id }
@@ -253,7 +253,7 @@ impl Drop for ImageLoader {
 
 			for handle in join_handles.into_iter() {
 				if let Err(err) = handle.join() {
-					eprintln!("Error occured while joining handle {:?}", err);
+					eprintln!("Error occurred while joining handle {:?}", err);
 				}
 			}
 		}

--- a/src/playback_manager.rs
+++ b/src/playback_manager.rs
@@ -488,7 +488,7 @@ impl ImgSequencePlayer {
 					self.file_path = None;
 					let stderr = &mut ::std::io::stderr();
 					let stderr_errmsg = "Error writing to stderr";
-					writeln!(stderr, "Error occured while loading image: {}", err)
+					writeln!(stderr, "Error occurred while loading image: {}", err)
 						.expect(stderr_errmsg);
 					for e in err.iter().skip(1) {
 						writeln!(stderr, "... caused by: {}", e).expect(stderr_errmsg);


### PR DESCRIPTION
When loading an image fails, this PR logs useful information _why_ the error occurred, and _for which file_.

This is how the output looks for me when I go through a directory containing unsupported/invalid files:

```
Request #13: Error occurred while loading file "/home/ludwig/Bilder/20160824_170638.jpg"
    Format error decoding Jpeg: invalid JPEG format: spectral selection is not allowed in non-progressive scan
Error occurred while loading image: Failed to load #13

Error occurred while loading image: Failed to load #13

Request #21: Error occurred while loading file "/home/ludwig/Bilder/rand.png"
    Format error decoding Png: CRC error
Error occurred while loading image: Failed to load #21

Error occurred while loading image: Failed to load #21

Error occurred while loading image: Failed to load #21

Error occurred while loading image: Failed to load #21

Error occurred while loading image: Failed to load #21

Error occurred while loading image: Failed to load #21

Request #18: Error occurred while loading file "/home/ludwig/Bilder/0.webp"
    The decoder for WebP does not support the format features ANIM
Error occurred while loading image: Failed to load #18

Error occurred while loading image: Failed to load #18
```

Before, it looked like this:

```
Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage

Error occured while loading image: FailedToLoadImage
```