### PR TITLE
Lexical sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,12 +16,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
-name = "alphanumeric-sort"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d338a8e22f0d04e4f44b0915c537d4dfa2e002ffa7ef78364de604d180b0448"
-
-[[package]]
 name = "andrew"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80115a2dfde04491e181c2440a39e4be26e52d9ca4e92bed213f65b94e0b8db1"
+
+[[package]]
 name = "directories-next"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,13 +494,13 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 name = "emulsion"
 version = "2.1.0"
 dependencies = [
- "alphanumeric-sort",
  "backtrace",
  "clap",
  "directories-next",
  "error-chain",
  "gelatin",
  "lazy_static",
+ "lexical-sort",
  "open",
  "rand 0.7.3",
  "serde",
@@ -837,6 +837,15 @@ name = "lazycell"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+
+[[package]]
+name = "lexical-sort"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff6260c96b887dd6e869c37c27e832a862c85d80d95e610863698e012ebd454"
+dependencies = [
+ "deunicode",
+]
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,6 @@ backtrace = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 rand = "0.7"
-lexical-sort = "0.1"
+lexical-sort = "0.2"
 trash = "1.0"
 clap = { version = "2.33", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,6 @@ backtrace = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"
 rand = "0.7"
-alphanumeric-sort = "1.0"
+lexical-sort = "0.1"
 trash = "1.0"
 clap = { version = "2.33", default-features = false }

--- a/src/image_cache/mod.rs
+++ b/src/image_cache/mod.rs
@@ -757,7 +757,10 @@ impl ImageCache {
 			.collect();
 
 		dir_files.sort_unstable_by(|a, b| {
-			alphanumeric_sort::compare_os_str(&a.dir_entry.file_name(), &b.dir_entry.file_name())
+			lexical_sort::lexical_natural_cmp(
+				&a.dir_entry.file_name().to_string_lossy(),
+				&b.dir_entry.file_name().to_string_lossy(),
+			)
 		});
 
 		Ok(dir_files)


### PR DESCRIPTION
This enables lexical, natural sorting of the files. It is case-insensitive and works with non-ASCII characters such as `ä á æ`. Numbers consisting of ASCII digits are sorted correctly, like before (e.g. `50` comes before `100`).

This uses the [lexical-sort](https://lib.rs/crates/lexical-sort) crate, which I wrote for this purpose. In my benchmarks, it was slower than the `alphanumeric-sort` crate or the standard library by a factor of 3 to 6, which I think is acceptable.

Fixes #102 