### PR TITLE
Update the directory contents when Emulsion regains focus.

### DIFF
--- a/src/picture_widget.rs
+++ b/src/picture_widget.rs
@@ -310,6 +310,14 @@ impl PictureWidget {
 		borrowed.set_img_size_to_fit(stretch);
 	}
 
+	pub fn reload_folder(&self) {
+		let mut borrowed = self.data.borrow_mut();
+		if let Err(e) = borrowed.playback_manager.update_directory() {
+			eprintln!("ERROR while reloading the folder: {}", e);
+		}
+		borrowed.render_validity.invalidate();
+	}
+
 	pub fn jump_to_index(&self, index: u32) {
 		let mut borrowed = self.data.borrow_mut();
 		borrowed.playback_manager.request_load(LoadRequest::LoadAtIndex(index as usize));
@@ -651,6 +659,15 @@ impl Widget for PictureWidget {
 					}
 				}
 				borrowed.render_validity.invalidate();
+			}
+			EventKind::Focused(focused) => {
+				if focused {
+					let mut borrowed = self.data.borrow_mut();
+					if let Err(e) = borrowed.playback_manager.update_directory() {
+						eprintln!("{}", e);
+					}
+					borrowed.render_validity.invalidate();
+				}
 			}
 		}
 	}

--- a/subcrates/gelatin/src/lib.rs
+++ b/subcrates/gelatin/src/lib.rs
@@ -335,6 +335,7 @@ pub enum EventKind {
 	DroppedFile(PathBuf),
 	HoveredFile(PathBuf),
 	HoveredFileCancelled,
+	Focused(bool),
 }
 
 #[derive(Copy, Clone)]

--- a/subcrates/gelatin/src/window.rs
+++ b/subcrates/gelatin/src/window.rs
@@ -340,6 +340,13 @@ impl Window {
 						kind: EventKind::HoveredFileCancelled,
 					});
 				}
+				WindowEvent::Focused(focused) => {
+					event = Some(Event {
+						cursor_pos: borrowed.cursor_pos,
+						modifiers: borrowed.modifiers,
+						kind: EventKind::Focused(focused),
+					});
+				}
 				WindowEvent::ModifiersChanged(modifiers) => {
 					borrowed.modifiers = modifiers;
 					event = None;


### PR DESCRIPTION
Fixes #28 

This also updates the currently open image when focus is regained.