### PR TITLE
improve CI build times

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,5 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      - name: Build and run tests
+        run: RUSTFLAGS="-C opt-level=0" cargo test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build and run tests
-        run: RUSTFLAGS="-C opt-level=0" cargo test --verbose
+        run: env RUSTFLAGS="-C opt-level=0" cargo test --verbose


### PR DESCRIPTION
I added `RUSTFLAGS` to set the optimization level in CI builds to 0. I also removed the `cargo build` command, because Cargo would otherwise build all dependencies twice because of `RUSTFLAGS`.

Closes #107