### PR TITLE
Fix opening relative path without parent

### DIFF
--- a/src/image_cache/mod.rs
+++ b/src/image_cache/mod.rs
@@ -762,7 +762,13 @@ fn get_file_name_and_parent(path: &Path) -> Result<(OsString, PathBuf)> {
 		None => bail!("Could not get file name from path {:?}", path),
 	};
 	let parent = match path.parent() {
-		Some(p) => p.canonicalize()?,
+		Some(p) => {
+			if p == Path::new("") {
+				Path::new(".").canonicalize()?
+			} else {
+				p.canonicalize()?
+			}
+		}
 		None => {
 			let mut path = path.canonicalize()?;
 			if !path.pop() {


### PR DESCRIPTION
`canonicalize()` returns an error if the given path is empty. Because of this, passing a single file name without `./` to emulsion failed.

Closes #119 