### PR TITLE
fix: don't reset index to 0 on file deletion

### DIFF
--- a/src/image_cache/directory.rs
+++ b/src/image_cache/directory.rs
@@ -215,10 +215,20 @@ impl Directory {
 	}
 
 	pub fn update_directory(&mut self) -> Result<()> {
-		let curr_filename = self.curr_filename();
+		let (curr_filename, curr_index) = (self.curr_filename(), self.curr_file_idx);
 		self.collect_directory()?;
+		// if possible preserve previous file_name
 		for (index, desc) in self.files.iter().enumerate() {
 			if desc.path.file_name().unwrap() == curr_filename {
+				self.curr_file_idx = index;
+				self.set_image_index_from_file_index();
+				self.check_filter_ready();
+				return Ok(());
+			}
+		}
+		// if is_file_supported, preserve index of previous file or its following files
+		for (index, desc) in self.files.iter().enumerate().skip(curr_index) {
+			if is_file_supported(&PathBuf::from(desc.path.file_name().unwrap())) {
 				self.curr_file_idx = index;
 				self.set_image_index_from_file_index();
 				self.check_filter_ready();

--- a/src/image_cache/directory.rs
+++ b/src/image_cache/directory.rs
@@ -215,9 +215,9 @@ impl Directory {
 	}
 
 	pub fn update_directory(&mut self) -> Result<()> {
-		let (curr_filename, curr_index) = (self.curr_filename(), self.curr_file_idx);
+		let curr_filename = self.curr_filename();
+		let curr_index = self.curr_file_idx;
 		self.collect_directory()?;
-		// if possible preserve previous file_name
 		for (index, desc) in self.files.iter().enumerate() {
 			if desc.path.file_name().unwrap() == curr_filename {
 				self.curr_file_idx = index;
@@ -228,7 +228,7 @@ impl Directory {
 		}
 		// if is_file_supported, preserve index of previous file or its following files
 		for (index, desc) in self.files.iter().enumerate().skip(curr_index) {
-			if is_file_supported(&PathBuf::from(desc.path.file_name().unwrap())) {
+			if is_file_supported(&desc.path) {
 				self.curr_file_idx = index;
 				self.set_image_index_from_file_index();
 				self.check_filter_ready();

--- a/src/widgets/picture_widget.rs
+++ b/src/widgets/picture_widget.rs
@@ -4,7 +4,7 @@ use std::rc::{Rc, Weak};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use gelatin::cgmath::{Matrix4, Rad, Vector3};
+use gelatin::cgmath::{Matrix4, Vector3};
 use gelatin::glium::glutin::event::{ElementState, ModifiersState, MouseButton};
 use gelatin::glium::{
 	program, uniform, uniforms::MagnifySamplerFilter, Display, Frame, Program, Surface,


### PR DESCRIPTION
The behavior before this PR was, that the index would be set to 0 on 
every file deletion.

This probably isn't the desired behavior. 
Now, the program first checks for the file-name, than the index and only after that setting the index to 0.