### PR TITLE
Add `start_maximized` configuration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Added
+- Added `start_maximized` configuration field
+
 ## 8.0 on 2021-01-02
 
 ### Changed

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -72,6 +72,7 @@ impl Default for CacheWindowSection {
 #[derive(Debug, Clone, Deserialize)]
 pub struct ConfigWindowSection {
 	pub start_fullscreen: Option<bool>,
+	pub start_maximized: Option<bool>,
 	pub show_bottom_bar: Option<bool>,
 	pub use_last_window_area: Option<bool>,
 	pub win_w: Option<u32>,

--- a/src/image_cache/directory.rs
+++ b/src/image_cache/directory.rs
@@ -37,8 +37,8 @@ macro_rules! step_to_next_img {
 				$this.curr_file_idx = i;
 				$this.set_image_index_from_file_index();
 				return;
-				}
 			}
+		}
 	};
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,10 @@ fn main() {
 		// the specified position when the position is specified during initialization
 		window.display_mut().gl_window().window().set_outer_position(pos);
 
+		if let Some(ConfigWindowSection { start_maximized: Some(true), .. }) = window_cfg {
+			window.set_maximized(true);
+		}
+
 		if let Some(ConfigWindowSection { start_fullscreen: Some(true), .. }) = window_cfg {
 			window.set_fullscreen(true);
 		}

--- a/src/widgets/picture_widget.rs
+++ b/src/widgets/picture_widget.rs
@@ -907,16 +907,16 @@ impl Widget for PictureWidget {
 								$name,
 								input_key_str.as_str(),
 								event.modifiers,
-								) {
+							) {
 								if $input == $dir && !pressed {
 									$input = MovementDir::None;
 									$vel = 0.0;
-									}
+								}
 								if $input != $dir && pressed {
 									borrowed.camera_movement_will_start();
 									$input = $dir;
-									}
 								}
+							}
 						};
 					}
 

--- a/subcrates/gelatin/src/window.rs
+++ b/subcrates/gelatin/src/window.rs
@@ -501,6 +501,10 @@ impl Window {
 		gl_win.window().set_fullscreen(monitor);
 	}
 
+	pub fn set_maximized(&self, maximized: bool) {
+		self.display_mut().gl_window().window().set_maximized(maximized);
+	}
+
 	/// Sets the alpha values by drawing a quad covering the entire framebuffer
 	/// with a blending mode set to max and a shader that draws (0,0,0,1) values
 	fn set_alpha_to_1(&self, target: &mut Frame, context: &DrawContext) {


### PR DESCRIPTION
Lately, I've been having some issues with emulsion not starting maximized anymore as it did before (a few months ago). Not sure what the issue is exactly but since I always want it to start maximized anyway I figured the easiest fix is to simply add a configuration flag for this.

There's a little bit of a conflict between setting the window position and maximizing it. I decided to just always set the position (as before) and maximize if requested after that. This causes the window to first show up unmaximized for half a second which is admittedly a bit janky but while it instantly appears maximized if I leave out setting the position, it also flashes white for a split moment which is pretty uncomfortable and less desirable in my opinion. This also has the advantage of the window remembering its position when unmaximized.

~~I also updated the dependencies of `gelatin` and fixed the resulting breakage caused by the `winit` upgrade. Let me know if you want me to split this part off into a separate PR.~~ *(Edit: I missed that there was already another PR working on this so I removed those changes)*

I also noticed quite a few clippy lints triggering, most of which seemed quite sensible, and I also get a deprecation warning for `compare_and_swap` on the latest Rust 1.50. Would you mind a PR to fix some of those?