### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/clipboard_handler.rs
+++ b/src/clipboard_handler.rs
@@ -4,7 +4,6 @@ use std::sync::{
 	Arc, Condvar, Mutex,
 };
 
-use arboard;
 use gelatin::image::imageops::{
 	flip_horizontal_in_place, flip_vertical_in_place, rotate180_in_place, rotate270, rotate90,
 };
@@ -36,7 +35,7 @@ impl ClipboardHandler {
 		let request_handle = Arc::new(ClipboardRequestHandle {
 			run_thread: AtomicBool::new(true),
 			condvar: Condvar::new(),
-			state: Mutex::new(prev_state.clone()),
+			state: Mutex::new(prev_state),
 		});
 		let handle = {
 			let request_handle = request_handle.clone();

--- a/src/image_cache/directory.rs
+++ b/src/image_cache/directory.rs
@@ -37,8 +37,8 @@ macro_rules! step_to_next_img {
 				$this.curr_file_idx = i;
 				$this.set_image_index_from_file_index();
 				return;
-				}
 			}
+		}
 	};
 }
 
@@ -161,7 +161,7 @@ impl Directory {
 				return Ok(());
 			}
 		}
-		Err(Error::Other(format!("Could not find image index")))
+		Err(Error::Other("Could not find image index".to_string()))
 	}
 
 	pub fn jump_to_prev(&mut self) {

--- a/src/image_cache/mod.rs
+++ b/src/image_cache/mod.rs
@@ -242,7 +242,7 @@ impl ImageCache {
 		let path = self
 			.dir
 			.image_by_index(index)
-			.ok_or(Error::from_kind(ErrorKind::WaitingOnDirFilter))?
+			.ok_or_else(|| Error::from_kind(ErrorKind::WaitingOnDirFilter))?
 			.path
 			.clone();
 
@@ -377,21 +377,19 @@ impl ImageCache {
 				self.dir.jump_to_prev();
 			}
 			target_path = self.dir.curr_descriptor().unwrap().path.clone();
-		} else {
-			if let (Some(curr_index), Some(img_count)) =
-				(self.dir.curr_img_index(), self.dir.image_count())
-			{
-				// rem_euclid calculates the least nonnegative remainder
-				let target_index = (curr_index as isize + file_jump_count as isize)
-					.rem_euclid(img_count as isize) as usize;
+		} else if let (Some(curr_index), Some(img_count)) =
+			(self.dir.curr_img_index(), self.dir.image_count())
+		{
+			// rem_euclid calculates the least nonnegative remainder
+			let target_index = (curr_index as isize + file_jump_count as isize)
+				.rem_euclid(img_count as isize) as usize;
 
-				target_path = self.dir.image_by_index(target_index).unwrap().path.clone();
-			} else {
-				bail!("Folder is empty, no folder was open, or folder hasn't finished filtering when trying to jump to an image by index.");
-			}
+			target_path = self.dir.image_by_index(target_index).unwrap().path.clone();
+		} else {
+			bail!("Folder is empty, no folder was open, or folder hasn't finished filtering when trying to jump to an image by index.");
 		}
 		let result = self.load_specific(display, &target_path, None)?;
-		return Ok((result, target_path));
+		Ok((result, target_path))
 	}
 
 	fn receive_prefetched(&mut self) {

--- a/src/image_cache/pending_requests.rs
+++ b/src/image_cache/pending_requests.rs
@@ -111,7 +111,7 @@ impl PendingRequests {
 		self.by_id.get(id).filter(|i| !i.finished)
 	}
 
-	pub fn iter_mut<'a>(&'a mut self) -> impl Iterator<Item = (&u32, &mut PendingRequestInfo)> {
+	pub fn iter_mut(&mut self) -> impl Iterator<Item = (&u32, &mut PendingRequestInfo)> {
 		self.by_id.iter_mut().filter(|(_, i)| !i.finished)
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,6 @@ fn main() {
 		});
 	}
 	{
-		let picture_widget = picture_widget.clone();
 		bottom_bar.fit_stretch_button.set_on_click(move || {
 			picture_widget.set_img_size_to_fit(true);
 		});
@@ -261,10 +260,8 @@ fn main() {
 
 	window.set_root(root_container);
 
-	let check_updates_enabled = match &config.borrow().updates {
-		Some(u) if !u.check_updates => false,
-		_ => true,
-	};
+	let check_updates_enabled =
+		config.borrow().updates.as_ref().map(|u| u.check_updates).unwrap_or(true);
 
 	let update_checker_join_handle = {
 		let updates = &mut cache.lock().unwrap().updates;

--- a/src/playback_manager.rs
+++ b/src/playback_manager.rs
@@ -154,13 +154,12 @@ impl PlaybackManager {
 			_ => 4,
 		};
 
-		let result = PlaybackManager {
+		PlaybackManager {
 			//playback_state: PlaybackState::Paused,
 			image_cache: ImageCache::new(cache_capaxity, thread_count),
 			folder_player: ImgSequencePlayer::new(),
 			image_player: ImgSequencePlayer::new(),
-		};
-		result
+		}
 	}
 
 	pub fn playback_state(&self) -> PlaybackState {
@@ -209,16 +208,13 @@ impl PlaybackManager {
 	}
 
 	pub fn update_directory(&mut self) -> image_cache::Result<()> {
-		match self.folder_player.load_request {
-			LoadRequest::None => {
-				let curr_path = self.image_cache.current_file_path();
-				if !curr_path.to_string_lossy().is_empty() {
-					self.image_cache.update_directory()?;
-					let path = self.current_file_path();
-					self.request_load(LoadRequest::FilePath(path));
-				}
+		if let LoadRequest::None = self.folder_player.load_request {
+			let curr_path = self.image_cache.current_file_path();
+			if !curr_path.to_string_lossy().is_empty() {
+				self.image_cache.update_directory()?;
+				let path = self.current_file_path();
+				self.request_load(LoadRequest::FilePath(path));
 			}
-			_ => (),
 		}
 		Ok(())
 	}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use gelatin::glium::glutin::event::VirtualKeyCode;
 
 pub fn virtual_keycode_is_char(vk: VirtualKeyCode) -> bool {
+	#[allow(clippy::match_like_matches_macro)]
 	match vk {
 		VirtualKeyCode::Key1 => true,
 		VirtualKeyCode::Key2 => true,

--- a/src/widgets/help_screen.rs
+++ b/src/widgets/help_screen.rs
@@ -41,8 +41,8 @@ pub struct HelpScreen {
 impl HelpScreen {
 	pub fn new(usage_img: Picture) -> HelpScreen {
 		let placement = WidgetPlacement {
-			width: Length::Fixed(0.0_f32),
-			height: Length::Fixed(0.0_f32),
+			width: Length::Fixed(0.0),
+			height: Length::Fixed(0.0),
 			horizontal_align: Alignment::Center,
 			vertical_align: Alignment::Center,
 			ignore_layout: true,

--- a/src/widgets/help_screen.rs
+++ b/src/widgets/help_screen.rs
@@ -41,8 +41,8 @@ pub struct HelpScreen {
 impl HelpScreen {
 	pub fn new(usage_img: Picture) -> HelpScreen {
 		let placement = WidgetPlacement {
-			width: Length::Fixed(0.0 as f32),
-			height: Length::Fixed(0.0 as f32),
+			width: Length::Fixed(0.0_f32),
+			height: Length::Fixed(0.0_f32),
 			horizontal_align: Alignment::Center,
 			vertical_align: Alignment::Center,
 			ignore_layout: true,

--- a/src/widgets/picture_widget.rs
+++ b/src/widgets/picture_widget.rs
@@ -50,10 +50,7 @@ pub enum MovementDir {
 
 impl MovementDir {
 	fn moving(self) -> bool {
-		match self {
-			MovementDir::None => false,
-			_ => true,
-		}
+		!matches!(self, MovementDir::None)
 	}
 }
 
@@ -669,11 +666,9 @@ impl Widget for PictureWidget {
 		data.set_window_title_filename(window, playback_state, data.playback_manager.file_path());
 		if prev_texture.is_none() != new_texture.is_none() {
 			data.render_validity.invalidate();
-		} else {
-			if let (Some(prev_tex), Some(new_tex)) = (prev_texture, new_texture) {
-				if !Rc::ptr_eq(&prev_tex.texture, &new_tex.texture) {
-					data.render_validity.invalidate();
-				}
+		} else if let (Some(prev_tex), Some(new_tex)) = (prev_texture, new_texture) {
+			if !Rc::ptr_eq(&prev_tex.texture, &new_tex.texture) {
+				data.render_validity.invalidate();
 			}
 		}
 		if let Some(clipboard_handler) = &data.clipboard_handler {
@@ -907,16 +902,16 @@ impl Widget for PictureWidget {
 								$name,
 								input_key_str.as_str(),
 								event.modifiers,
-								) {
+							) {
 								if $input == $dir && !pressed {
 									$input = MovementDir::None;
 									$vel = 0.0;
-									}
+								}
 								if $input != $dir && pressed {
 									borrowed.camera_movement_will_start();
 									$input = $dir;
-									}
 								}
+							}
 						};
 					}
 

--- a/subcrates/gelatin/src/application.rs
+++ b/subcrates/gelatin/src/application.rs
@@ -129,10 +129,7 @@ impl Application {
 				}
 				Event::MainEventsCleared => {
 					if !EXIT_REQUESTED.load(Ordering::Relaxed) {
-						let mut should_sleep = match control_flow {
-							ControlFlow::Poll => false,
-							_ => true,
-						};
+						let mut should_sleep = !matches!(control_flow, ControlFlow::Poll);
 						for (window_id, window) in windows.iter() {
 							let new_control_flow = window.main_events_cleared().into();
 							update_control_flow(

--- a/subcrates/gelatin/src/slider.rs
+++ b/subcrates/gelatin/src/slider.rs
@@ -257,3 +257,9 @@ impl Widget for Slider {
 		self.data.borrow_mut().render_validity = render_validity;
 	}
 }
+
+impl Default for Slider {
+	fn default() -> Self {
+		Self::new()
+	}
+}

--- a/subcrates/gelatin/src/window.rs
+++ b/subcrates/gelatin/src/window.rs
@@ -161,7 +161,7 @@ impl Window {
 
 		// building the index buffer
 		let index_buffer =
-			IndexBuffer::new(&display, PrimitiveType::TriangleStrip, &[1 as u16, 2, 0, 3]).unwrap();
+			IndexBuffer::new(&display, PrimitiveType::TriangleStrip, &[1_u16, 2, 0, 3]).unwrap();
 
 		// compiling shaders and linking them together
 		let textured_program = program!(&display,
@@ -369,11 +369,8 @@ impl Window {
 			let mut borrowed = self.data.borrow_mut();
 			borrowed.should_sleep = false;
 			if borrowed.render_validity.get() {
-				match event.kind {
-					EventKind::MouseMove => {
-						borrowed.should_sleep = true;
-					}
-					_ => (),
+				if let EventKind::MouseMove = event.kind {
+					borrowed.should_sleep = true;
 				}
 			} else {
 				borrowed.last_event_invalidated = true;
@@ -440,9 +437,9 @@ impl Window {
 		let projection_transform = ortho(left, right, bottom, top, -1f32, 1f32);
 
 		let viewport = Rect {
-			left: 0 as u32,
+			left: 0_u32,
 			width: phys_width as u32,
-			bottom: 0 as u32,
+			bottom: 0_u32,
 			height: phys_height as u32,
 		};
 


### PR DESCRIPTION
Most of them seem fairly obvious. The only ones I think are a bit questionable are the ones that produce `!matches!(...)`. It also doesn't like `matches!(..) == false`. Maybe `matches!(..).not()` would be the cleanest alternative? Would be nice if we had a `not ...` keyword in the language like in Python.

Another notable change is removing the `Result` from `load_animation` (https://github.com/ArturKovacs/emulsion/pull/185/files#diff-c07bf01b9ca4764ed4575820b9c711f2a0cd40f86bcdd4b7cfdbc0119f6bc58cR231) since it can't actually fail which leads to removing a `?` and adding a `Ok(..)` somewhere else.

And `clippy` also wants an `impl Default for Slider`. Seems reasonable but let me know what you think.

The deprecation warnings are already being fixed in #179.

Also, this is obviously not urgent, so take your time with the review :)