### PR TITLE
Box ureq errors to fix clippy warning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -450,7 +450,7 @@ mod update {
 		error_chain! {
 			foreign_links {
 				Io(std::io::Error);
-				Ureq(ureq::Error);
+				Ureq(Box<ureq::Error>);
 				ParseIntError(std::num::ParseIntError);
 			}
 		}
@@ -465,7 +465,7 @@ mod update {
 				let release_info = res.into_json()?;
 				Ok(release_info)
 			}
-			Err(err) => Err(err.into()),
+			Err(err) => Err(Box::new(err).into()),
 		}
 	}
 


### PR DESCRIPTION
This should fix the last clippy warning introduced by the `ureq` upgrade. The complaint is that the `ureq` error is very large, much larger than the other error variants in the `error_chain` error definition. I just boxed the error variant as is the usual solution. I guess just silencing the warning works as well but this is probably a bit more performant on the happy path. Not that it really matters.