### PR TITLE
Add toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This avoids unspecified toolchain errors
when e.g. doing a clean build (with empty $HOME)
in some versions of rustup.

E.g. on ArchLinux you can otherwise get:
```
error: no override and no default toolchain set
```