### PR TITLE
Enhance: set dark mode in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 ### Changed
 - Fix for not being able to delete images on some systems.
-- Change antialias configuration keywords to snake_case.
 
 ## 9.0 on 2021-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## Unreleased
 
+### Added
+- Added configuration keyword to switch between dark and light mode.
+
 ### Changed
 - Fix for not being able to delete images on some systems.
+- Change antialias configuration keywords to snake_case.
 
 ## 9.0 on 2021-04-27
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
 pub enum Theme {
 	Light,
 	Dark,
@@ -230,6 +230,7 @@ pub struct Configuration {
 	pub title: Option<TitleSection>,
 	pub image: Option<ConfigImageSection>,
 	pub window: Option<ConfigWindowSection>,
+	pub theme: Option<Theme>,
 }
 impl Configuration {
 	pub fn load<P: AsRef<Path>>(file_path: P) -> Result<Configuration, String> {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum Theme {
 	Light,
 	Dark,
@@ -30,6 +31,7 @@ impl Theme {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Antialias {
 	#[serde(rename = "auto")]
 	Auto,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -33,11 +33,8 @@ impl Theme {
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Antialias {
-	#[serde(rename = "auto")]
 	Auto,
-	#[serde(rename = "always")]
 	Always,
-	#[serde(rename = "never")]
 	Never,
 }
 impl Default for Antialias {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -76,6 +76,7 @@ pub struct ConfigWindowSection {
 	pub start_fullscreen: Option<bool>,
 	pub start_maximized: Option<bool>,
 	pub show_bottom_bar: Option<bool>,
+	pub theme: Option<Theme>,
 	pub use_last_window_area: Option<bool>,
 	pub win_w: Option<u32>,
 	pub win_h: Option<u32>,
@@ -232,7 +233,6 @@ pub struct Configuration {
 	pub title: Option<TitleSection>,
 	pub image: Option<ConfigImageSection>,
 	pub window: Option<ConfigWindowSection>,
-	pub theme: Option<Theme>,
 }
 impl Configuration {
 	pub fn load<P: AsRef<Path>>(file_path: P) -> Result<Configuration, String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,13 @@ fn main() {
 
 	let update_available = Arc::new(AtomicBool::new(false));
 	let update_check_done = Arc::new(AtomicBool::new(false));
-	let theme = Rc::new(Cell::new(cache.lock().unwrap().theme()));
+
+	let theme = {
+		Rc::new(Cell::new(match &config.borrow().theme {
+			Some(theme_cfg) => *theme_cfg,
+			None => cache.lock().unwrap().theme(),
+		}))
+	};
 
 	let set_theme = {
 		let update_label = update_label;

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,9 +187,9 @@ fn main() {
 	let update_check_done = Arc::new(AtomicBool::new(false));
 
 	let theme = {
-		Rc::new(Cell::new(match &config.borrow().theme {
-			Some(theme_cfg) => *theme_cfg,
-			None => cache.lock().unwrap().theme(),
+		Rc::new(Cell::new(match &config.borrow().window {
+			Some(ConfigWindowSection { theme: Some(theme_cfg), .. }) => *theme_cfg,
+			_ => cache.lock().unwrap().theme(),
 		}))
 	};
 


### PR DESCRIPTION
### Description
As a user, I'd like to set dark mode in the configuration file, mainly because that is something a user may expect to set there (and I have the bar hidden so I can't just rely on the cache for fresh installs with my config files).

This PR simply adds a field theme at the root of the `cfg.toml` file:

```toml
theme="Dark"

[bindings]
# everything remains the same
```

### Implementation
A field `theme` was added to [`Configuration`](https://github.com/ArturKovacs/emulsion/blob/master/src/configuration.rs#L226), in the same fashion than `Cache`. Points to consider:

* This configuration field takes precedence over cache's as in the `window` field, is that fine?
* `Serialize` and `Deserialize` were derived for `Theme`, what do you think of [`#[serde(rename_all = "lowercase")]`](https://serde.rs/container-attrs.html#rename_all) so that it becomes the following at `cfg.toml`:
```toml
theme="dark"
```
* The default stays the same (Light).
* Maybe `theme` should be a field of [`ConfigWindowSection`](https://github.com/ArturKovacs/emulsion/blob/master/src/configuration.rs#L73) (?), whatever is cleaner.